### PR TITLE
Print screen contents to stdout on exit

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -287,9 +287,12 @@ func (app *App) init() error {
 }
 
 func (app *App) cleanup() {
-	if app.screen != nil {
-		dump := CaptureScreen(app.screen)
-		app.screen.Fini()
+	scr := app.screen
+	if scr != nil {
+		// Make cleanup idempotent: after this point, app.screen is considered finalized.
+		app.screen = nil
+		dump := CaptureScreen(scr)
+		scr.Fini()
 		fmt.Print(dump)
 	}
 }

--- a/app/app.go
+++ b/app/app.go
@@ -231,9 +231,6 @@ func (app *App) loop() {
 func (app *App) handleStateEvent(event dux.StateEvent) (quit bool) {
 	if event.State.Quit {
 		log.Printf("App got Quit event, terminating updateLoop!")
-		// TODO we actually the last (and only the last) alternate screen
-		// to end up in the scrollback buffer
-		app.clearAlternateScreen()
 		app.closeTcellEventChannel()
 		return true
 	}
@@ -291,7 +288,9 @@ func (app *App) init() error {
 
 func (app *App) cleanup() {
 	if app.screen != nil {
+		dump := CaptureScreen(app.screen)
 		app.screen.Fini()
+		fmt.Print(dump)
 	}
 }
 

--- a/app/screendump.go
+++ b/app/screendump.go
@@ -1,0 +1,134 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+// CaptureScreen reads the contents of a tcell screen buffer and returns a
+// string with ANSI escape sequences that reproduces the screen's appearance.
+func CaptureScreen(screen tcell.Screen) string {
+	w, h := screen.Size()
+	if w == 0 || h == 0 {
+		return ""
+	}
+
+	var buf strings.Builder
+	var prevStyle tcell.Style
+	styleWritten := false
+
+	for y := 0; y < h; y++ {
+		// Collect the row's cells so we can trim trailing default spaces.
+		type cell struct {
+			mainc rune
+			combc []rune
+			style tcell.Style
+			width int
+		}
+		row := make([]cell, 0, w)
+		for x := 0; x < w; x++ {
+			mainc, combc, style, width := screen.GetContent(x, y)
+			if width == 0 {
+				// Continuation cell of a wide character; skip.
+				continue
+			}
+			row = append(row, cell{mainc, combc, style, width})
+		}
+
+		// Trim trailing spaces that have the default style.
+		trimmed := row
+		for len(trimmed) > 0 {
+			last := trimmed[len(trimmed)-1]
+			if last.mainc == ' ' && len(last.combc) == 0 && last.style == tcell.StyleDefault {
+				trimmed = trimmed[:len(trimmed)-1]
+			} else {
+				break
+			}
+		}
+
+		for _, c := range trimmed {
+			if !styleWritten || c.style != prevStyle {
+				writeStyle(&buf, c.style)
+				prevStyle = c.style
+				styleWritten = true
+			}
+			if c.mainc == 0 {
+				buf.WriteRune(' ')
+			} else {
+				buf.WriteRune(c.mainc)
+			}
+			for _, r := range c.combc {
+				buf.WriteRune(r)
+			}
+		}
+
+		// Reset style at end of line to prevent background bleed.
+		if styleWritten {
+			buf.WriteString("\033[0m")
+			styleWritten = false
+		}
+		if y < h-1 {
+			buf.WriteRune('\n')
+		}
+	}
+
+	return buf.String()
+}
+
+// writeStyle emits an ANSI SGR sequence that sets the given style.
+func writeStyle(buf *strings.Builder, style tcell.Style) {
+	fg, bg, attrs := style.Decompose()
+
+	buf.WriteString("\033[0")
+
+	if attrs&tcell.AttrBold != 0 {
+		buf.WriteString(";1")
+	}
+	if attrs&tcell.AttrDim != 0 {
+		buf.WriteString(";2")
+	}
+	if attrs&tcell.AttrItalic != 0 {
+		buf.WriteString(";3")
+	}
+	if attrs&tcell.AttrUnderline != 0 {
+		buf.WriteString(";4")
+	}
+	if attrs&tcell.AttrBlink != 0 {
+		buf.WriteString(";5")
+	}
+	if attrs&tcell.AttrReverse != 0 {
+		buf.WriteString(";7")
+	}
+	if attrs&tcell.AttrStrikeThrough != 0 {
+		buf.WriteString(";9")
+	}
+
+	writeColor(buf, fg, 30)
+	writeColor(buf, bg, 40)
+
+	buf.WriteRune('m')
+}
+
+// writeColor appends SGR parameters for a color. base is 30 for foreground
+// or 40 for background.
+func writeColor(buf *strings.Builder, c tcell.Color, base int) {
+	if !c.Valid() {
+		return
+	}
+	if c.IsRGB() {
+		r, g, b := c.RGB()
+		fmt.Fprintf(buf, ";%d;2;%d;%d;%d", base+8, r, g, b)
+		return
+	}
+	idx := int(c & 0xff)
+	switch {
+	case idx < 8:
+		fmt.Fprintf(buf, ";%d", base+idx)
+	case idx < 16:
+		fmt.Fprintf(buf, ";%d", base+60+idx-8)
+	default:
+		fmt.Fprintf(buf, ";%d;5;%d", base+8, idx)
+	}
+}

--- a/app/screendump.go
+++ b/app/screendump.go
@@ -7,6 +7,34 @@ import (
 	"github.com/gdamore/tcell/v2"
 )
 
+// ANSI terminal escape constants.
+// Reference: ECMA-48 §8.3.117, https://en.wikipedia.org/wiki/ANSI_escape_code#SGR
+const (
+	csi    = "\033[" // Control Sequence Introducer (ESC + '[')
+	sgrEnd = "m"     // SGR (Select Graphic Rendition) sequence terminator
+
+	sgrReset         = "0"
+	sgrBold          = ";1"
+	sgrDim           = ";2"
+	sgrItalic        = ";3"
+	sgrUnderline     = ";4"
+	sgrBlink         = ";5"
+	sgrReverse       = ";7"
+	sgrStrikethrough = ";9"
+
+	sgrFgBase = 30 // standard foreground colors: 30-37
+	sgrBgBase = 40 // standard background colors: 40-47
+
+	sgrColorExtendedOffset = 8  // base+8 = 38 (fg) or 48 (bg) for extended colors
+	sgrColorRGB            = 2  // extended color sub-mode for 24-bit RGB
+	sgrColor256            = 5  // extended color sub-mode for 256-color palette
+	sgrHighIntensityOffset = 60 // offset from standard to bright colors (e.g., 30→90)
+
+	colorIndexMask        = 0xff // mask to extract palette index from tcell.Color
+	colorStandardCount    = 8    // standard colors: indices 0-7
+	colorHighIntensityEnd = 16   // high-intensity colors: indices 8-15
+)
+
 // CaptureScreen reads the contents of a tcell screen buffer and returns a
 // string with ANSI escape sequences that reproduces the screen's appearance.
 func CaptureScreen(screen tcell.Screen) string {
@@ -66,7 +94,7 @@ func CaptureScreen(screen tcell.Screen) string {
 
 		// Reset style at end of line to prevent background bleed.
 		if styleWritten {
-			buf.WriteString("\033[0m")
+			buf.WriteString(csi + sgrReset + sgrEnd)
 			styleWritten = false
 		}
 		if y < h-1 {
@@ -81,54 +109,54 @@ func CaptureScreen(screen tcell.Screen) string {
 func writeStyle(buf *strings.Builder, style tcell.Style) {
 	fg, bg, attrs := style.Decompose()
 
-	buf.WriteString("\033[0")
+	buf.WriteString(csi + sgrReset)
 
 	if attrs&tcell.AttrBold != 0 {
-		buf.WriteString(";1")
+		buf.WriteString(sgrBold)
 	}
 	if attrs&tcell.AttrDim != 0 {
-		buf.WriteString(";2")
+		buf.WriteString(sgrDim)
 	}
 	if attrs&tcell.AttrItalic != 0 {
-		buf.WriteString(";3")
+		buf.WriteString(sgrItalic)
 	}
 	if attrs&tcell.AttrUnderline != 0 {
-		buf.WriteString(";4")
+		buf.WriteString(sgrUnderline)
 	}
 	if attrs&tcell.AttrBlink != 0 {
-		buf.WriteString(";5")
+		buf.WriteString(sgrBlink)
 	}
 	if attrs&tcell.AttrReverse != 0 {
-		buf.WriteString(";7")
+		buf.WriteString(sgrReverse)
 	}
 	if attrs&tcell.AttrStrikeThrough != 0 {
-		buf.WriteString(";9")
+		buf.WriteString(sgrStrikethrough)
 	}
 
-	writeColor(buf, fg, 30)
-	writeColor(buf, bg, 40)
+	writeColor(buf, fg, sgrFgBase)
+	writeColor(buf, bg, sgrBgBase)
 
-	buf.WriteRune('m')
+	buf.WriteString(sgrEnd)
 }
 
-// writeColor appends SGR parameters for a color. base is 30 for foreground
-// or 40 for background.
+// writeColor appends SGR parameters for a color. base is sgrFgBase for
+// foreground or sgrBgBase for background.
 func writeColor(buf *strings.Builder, c tcell.Color, base int) {
 	if !c.Valid() {
 		return
 	}
 	if c.IsRGB() {
 		r, g, b := c.RGB()
-		fmt.Fprintf(buf, ";%d;2;%d;%d;%d", base+8, r, g, b)
+		fmt.Fprintf(buf, ";%d;%d;%d;%d;%d", base+sgrColorExtendedOffset, sgrColorRGB, r, g, b)
 		return
 	}
-	idx := int(c & 0xff)
+	idx := int(c & colorIndexMask)
 	switch {
-	case idx < 8:
+	case idx < colorStandardCount:
 		fmt.Fprintf(buf, ";%d", base+idx)
-	case idx < 16:
-		fmt.Fprintf(buf, ";%d", base+60+idx-8)
+	case idx < colorHighIntensityEnd:
+		fmt.Fprintf(buf, ";%d", base+sgrHighIntensityOffset+idx-colorStandardCount)
 	default:
-		fmt.Fprintf(buf, ";%d;5;%d", base+8, idx)
+		fmt.Fprintf(buf, ";%d;%d;%d", base+sgrColorExtendedOffset, sgrColor256, idx)
 	}
 }

--- a/app/screendump_test.go
+++ b/app/screendump_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/jensgreen/dux/app/testutil"
 	"github.com/gdamore/tcell/v2"
 	"github.com/stretchr/testify/assert"
 )
@@ -42,18 +43,8 @@ var (
 	bgBlue   = sgrBg(12)
 )
 
-func initScreen(t *testing.T, w, h int) tcell.SimulationScreen {
-	t.Helper()
-	screen := tcell.NewSimulationScreen("")
-	if err := screen.Init(); err != nil {
-		t.Fatal(err)
-	}
-	screen.SetSize(w, h)
-	return screen
-}
-
 func TestCaptureScreen_PlainText(t *testing.T) {
-	screen := initScreen(t, 10, 2)
+	screen := testutil.InitSimScreen(t, 10, 2)
 	putString(screen, 0, 0, "hello", tcell.StyleDefault)
 	putString(screen, 0, 1, "world", tcell.StyleDefault)
 	screen.Show()
@@ -63,7 +54,7 @@ func TestCaptureScreen_PlainText(t *testing.T) {
 }
 
 func TestCaptureScreen_TrailingSpacesTrimmed(t *testing.T) {
-	screen := initScreen(t, 10, 1)
+	screen := testutil.InitSimScreen(t, 10, 1)
 	putString(screen, 0, 0, "hi", tcell.StyleDefault)
 	screen.Show()
 
@@ -72,7 +63,7 @@ func TestCaptureScreen_TrailingSpacesTrimmed(t *testing.T) {
 }
 
 func TestCaptureScreen_TrailingSpacesWithColorPreserved(t *testing.T) {
-	screen := initScreen(t, 5, 1)
+	screen := testutil.InitSimScreen(t, 5, 1)
 	style := tcell.StyleDefault.Background(tcell.ColorBlue)
 	for x := 0; x < 5; x++ {
 		screen.SetContent(x, 0, ' ', nil, style)
@@ -84,7 +75,7 @@ func TestCaptureScreen_TrailingSpacesWithColorPreserved(t *testing.T) {
 }
 
 func TestCaptureScreen_ForegroundColor(t *testing.T) {
-	screen := initScreen(t, 5, 1)
+	screen := testutil.InitSimScreen(t, 5, 1)
 	style := tcell.StyleDefault.Foreground(tcell.ColorRed)
 	putString(screen, 0, 0, "red", style)
 	screen.Show()
@@ -94,7 +85,7 @@ func TestCaptureScreen_ForegroundColor(t *testing.T) {
 }
 
 func TestCaptureScreen_BoldItalicYellow(t *testing.T) {
-	screen := initScreen(t, 5, 1)
+	screen := testutil.InitSimScreen(t, 5, 1)
 	style := tcell.StyleDefault.Bold(true).Italic(true).Foreground(tcell.ColorYellow)
 	putString(screen, 0, 0, "hi", style)
 	screen.Show()
@@ -104,7 +95,7 @@ func TestCaptureScreen_BoldItalicYellow(t *testing.T) {
 }
 
 func TestCaptureScreen_StyleChangeMidRow(t *testing.T) {
-	screen := initScreen(t, 6, 1)
+	screen := testutil.InitSimScreen(t, 6, 1)
 	putString(screen, 0, 0, "ab", tcell.StyleDefault.Foreground(tcell.ColorRed))
 	putString(screen, 2, 0, "cd", tcell.StyleDefault.Foreground(tcell.ColorBlue))
 	screen.Show()
@@ -114,7 +105,7 @@ func TestCaptureScreen_StyleChangeMidRow(t *testing.T) {
 }
 
 func TestCaptureScreen_BackgroundAndForeground(t *testing.T) {
-	screen := initScreen(t, 3, 1)
+	screen := testutil.InitSimScreen(t, 3, 1)
 	style := tcell.StyleDefault.Foreground(tcell.ColorWhite).Background(tcell.ColorGreen)
 	putString(screen, 0, 0, "bar", style)
 	screen.Show()
@@ -124,7 +115,7 @@ func TestCaptureScreen_BackgroundAndForeground(t *testing.T) {
 }
 
 func TestCaptureScreen_StandardColor(t *testing.T) {
-	screen := initScreen(t, 5, 1)
+	screen := testutil.InitSimScreen(t, 5, 1)
 	// ColorBlack (index 0) is a standard color, should use base range (30-37).
 	style := tcell.StyleDefault.Foreground(tcell.ColorBlack)
 	putString(screen, 0, 0, "dark", style)
@@ -135,7 +126,7 @@ func TestCaptureScreen_StandardColor(t *testing.T) {
 }
 
 func TestCaptureScreen_HighIntensityColor(t *testing.T) {
-	screen := initScreen(t, 5, 1)
+	screen := testutil.InitSimScreen(t, 5, 1)
 	// ColorRed (index 9) is a high-intensity color, should use bright range (90-97).
 	style := tcell.StyleDefault.Foreground(tcell.ColorRed)
 	putString(screen, 0, 0, "glow", style)
@@ -146,7 +137,7 @@ func TestCaptureScreen_HighIntensityColor(t *testing.T) {
 }
 
 func TestCaptureScreen_StandardAndHighIntensityBackground(t *testing.T) {
-	screen := initScreen(t, 6, 1)
+	screen := testutil.InitSimScreen(t, 6, 1)
 	// ColorGreen (index 2) is standard, ColorBlue (index 12) is high-intensity.
 	putString(screen, 0, 0, "std", tcell.StyleDefault.Background(tcell.ColorGreen))
 	putString(screen, 3, 0, "brt", tcell.StyleDefault.Background(tcell.ColorBlue))
@@ -157,7 +148,7 @@ func TestCaptureScreen_StandardAndHighIntensityBackground(t *testing.T) {
 }
 
 func TestCaptureScreen_EmptyScreen(t *testing.T) {
-	screen := initScreen(t, 5, 2)
+	screen := testutil.InitSimScreen(t, 5, 2)
 	screen.Show()
 
 	got := CaptureScreen(screen)
@@ -166,7 +157,7 @@ func TestCaptureScreen_EmptyScreen(t *testing.T) {
 }
 
 func TestCaptureScreen_ZeroSize(t *testing.T) {
-	screen := initScreen(t, 0, 0)
+	screen := testutil.InitSimScreen(t, 0, 0)
 	got := CaptureScreen(screen)
 	assert.Equal(t, "", got)
 }

--- a/app/screendump_test.go
+++ b/app/screendump_test.go
@@ -1,0 +1,111 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func initScreen(t *testing.T, w, h int) tcell.SimulationScreen {
+	t.Helper()
+	screen := tcell.NewSimulationScreen("")
+	if err := screen.Init(); err != nil {
+		t.Fatal(err)
+	}
+	screen.SetSize(w, h)
+	return screen
+}
+
+func TestCaptureScreen_PlainText(t *testing.T) {
+	screen := initScreen(t, 10, 2)
+	putString(screen, 0, 0, "hello", tcell.StyleDefault)
+	putString(screen, 0, 1, "world", tcell.StyleDefault)
+	screen.Show()
+
+	got := CaptureScreen(screen)
+	assert.Equal(t, "\033[0mhello\033[0m\n\033[0mworld\033[0m", got)
+}
+
+func TestCaptureScreen_TrailingSpacesTrimmed(t *testing.T) {
+	screen := initScreen(t, 10, 1)
+	putString(screen, 0, 0, "hi", tcell.StyleDefault)
+	screen.Show()
+
+	got := CaptureScreen(screen)
+	assert.Equal(t, "\033[0mhi\033[0m", got)
+}
+
+func TestCaptureScreen_TrailingSpacesWithColorPreserved(t *testing.T) {
+	screen := initScreen(t, 5, 1)
+	style := tcell.StyleDefault.Background(tcell.ColorBlue)
+	for x := 0; x < 5; x++ {
+		screen.SetContent(x, 0, ' ', nil, style)
+	}
+	screen.Show()
+
+	got := CaptureScreen(screen)
+	assert.Equal(t, "\033[0;104m     \033[0m", got)
+}
+
+func TestCaptureScreen_ForegroundColor(t *testing.T) {
+	screen := initScreen(t, 5, 1)
+	style := tcell.StyleDefault.Foreground(tcell.ColorRed)
+	putString(screen, 0, 0, "red", style)
+	screen.Show()
+
+	got := CaptureScreen(screen)
+	assert.Equal(t, "\033[0;91mred\033[0m", got)
+}
+
+func TestCaptureScreen_BoldItalic(t *testing.T) {
+	screen := initScreen(t, 5, 1)
+	style := tcell.StyleDefault.Bold(true).Italic(true).Foreground(tcell.ColorYellow)
+	putString(screen, 0, 0, "hi", style)
+	screen.Show()
+
+	got := CaptureScreen(screen)
+	assert.Equal(t, "\033[0;1;3;93mhi\033[0m", got)
+}
+
+func TestCaptureScreen_StyleChangeMidRow(t *testing.T) {
+	screen := initScreen(t, 6, 1)
+	putString(screen, 0, 0, "ab", tcell.StyleDefault.Foreground(tcell.ColorRed))
+	putString(screen, 2, 0, "cd", tcell.StyleDefault.Foreground(tcell.ColorBlue))
+	screen.Show()
+
+	got := CaptureScreen(screen)
+	assert.Equal(t, "\033[0;91mab\033[0;94mcd\033[0m", got)
+}
+
+func TestCaptureScreen_BackgroundAndForeground(t *testing.T) {
+	screen := initScreen(t, 3, 1)
+	style := tcell.StyleDefault.Foreground(tcell.ColorWhite).Background(tcell.ColorGreen)
+	putString(screen, 0, 0, "bar", style)
+	screen.Show()
+
+	got := CaptureScreen(screen)
+	assert.Equal(t, "\033[0;97;42mbar\033[0m", got)
+}
+
+func TestCaptureScreen_EmptyScreen(t *testing.T) {
+	screen := initScreen(t, 5, 2)
+	screen.Show()
+
+	got := CaptureScreen(screen)
+	// All default spaces trimmed, just newline between rows.
+	assert.Equal(t, "\n", got)
+}
+
+func TestCaptureScreen_ZeroSize(t *testing.T) {
+	screen := initScreen(t, 0, 0)
+	got := CaptureScreen(screen)
+	assert.Equal(t, "", got)
+}
+
+func putString(screen tcell.SimulationScreen, x, y int, s string, style tcell.Style) {
+	for _, r := range s {
+		screen.SetContent(x, y, r, nil, style)
+		x++
+	}
+}

--- a/app/screendump_test.go
+++ b/app/screendump_test.go
@@ -1,10 +1,45 @@
 package app
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/stretchr/testify/assert"
+)
+
+// sgr builds an ANSI SGR escape sequence from the given parameters.
+func sgr(params string) string {
+	return csi + params + sgrEnd
+}
+
+// sgrFg returns an SGR foreground color parameter for a palette index.
+func sgrFg(idx int) string {
+	if idx < colorStandardCount {
+		return fmt.Sprintf(";%d", sgrFgBase+idx)
+	}
+	return fmt.Sprintf(";%d", sgrFgBase+sgrHighIntensityOffset+idx-colorStandardCount)
+}
+
+// sgrBg returns an SGR background color parameter for a palette index.
+func sgrBg(idx int) string {
+	if idx < colorStandardCount {
+		return fmt.Sprintf(";%d", sgrBgBase+idx)
+	}
+	return fmt.Sprintf(";%d", sgrBgBase+sgrHighIntensityOffset+idx-colorStandardCount)
+}
+
+var (
+	reset = sgr(sgrReset)
+
+	// tcell color indices (from tcell's color constants):
+	//   ColorGreen=2, ColorRed=9, ColorYellow=11, ColorBlue=12, ColorWhite=15
+	fgRed    = sgrFg(9)
+	fgYellow = sgrFg(11)
+	fgBlue   = sgrFg(12)
+	fgWhite  = sgrFg(15)
+	bgGreen  = sgrBg(2)
+	bgBlue   = sgrBg(12)
 )
 
 func initScreen(t *testing.T, w, h int) tcell.SimulationScreen {
@@ -24,7 +59,7 @@ func TestCaptureScreen_PlainText(t *testing.T) {
 	screen.Show()
 
 	got := CaptureScreen(screen)
-	assert.Equal(t, "\033[0mhello\033[0m\n\033[0mworld\033[0m", got)
+	assert.Equal(t, sgr(sgrReset)+"hello"+reset+"\n"+sgr(sgrReset)+"world"+reset, got)
 }
 
 func TestCaptureScreen_TrailingSpacesTrimmed(t *testing.T) {
@@ -33,7 +68,7 @@ func TestCaptureScreen_TrailingSpacesTrimmed(t *testing.T) {
 	screen.Show()
 
 	got := CaptureScreen(screen)
-	assert.Equal(t, "\033[0mhi\033[0m", got)
+	assert.Equal(t, sgr(sgrReset)+"hi"+reset, got)
 }
 
 func TestCaptureScreen_TrailingSpacesWithColorPreserved(t *testing.T) {
@@ -45,7 +80,7 @@ func TestCaptureScreen_TrailingSpacesWithColorPreserved(t *testing.T) {
 	screen.Show()
 
 	got := CaptureScreen(screen)
-	assert.Equal(t, "\033[0;104m     \033[0m", got)
+	assert.Equal(t, sgr(sgrReset+bgBlue)+"     "+reset, got)
 }
 
 func TestCaptureScreen_ForegroundColor(t *testing.T) {
@@ -55,17 +90,17 @@ func TestCaptureScreen_ForegroundColor(t *testing.T) {
 	screen.Show()
 
 	got := CaptureScreen(screen)
-	assert.Equal(t, "\033[0;91mred\033[0m", got)
+	assert.Equal(t, sgr(sgrReset+fgRed)+"red"+reset, got)
 }
 
-func TestCaptureScreen_BoldItalic(t *testing.T) {
+func TestCaptureScreen_BoldItalicYellow(t *testing.T) {
 	screen := initScreen(t, 5, 1)
 	style := tcell.StyleDefault.Bold(true).Italic(true).Foreground(tcell.ColorYellow)
 	putString(screen, 0, 0, "hi", style)
 	screen.Show()
 
 	got := CaptureScreen(screen)
-	assert.Equal(t, "\033[0;1;3;93mhi\033[0m", got)
+	assert.Equal(t, sgr(sgrReset+sgrBold+sgrItalic+fgYellow)+"hi"+reset, got)
 }
 
 func TestCaptureScreen_StyleChangeMidRow(t *testing.T) {
@@ -75,7 +110,7 @@ func TestCaptureScreen_StyleChangeMidRow(t *testing.T) {
 	screen.Show()
 
 	got := CaptureScreen(screen)
-	assert.Equal(t, "\033[0;91mab\033[0;94mcd\033[0m", got)
+	assert.Equal(t, sgr(sgrReset+fgRed)+"ab"+sgr(sgrReset+fgBlue)+"cd"+reset, got)
 }
 
 func TestCaptureScreen_BackgroundAndForeground(t *testing.T) {
@@ -85,7 +120,40 @@ func TestCaptureScreen_BackgroundAndForeground(t *testing.T) {
 	screen.Show()
 
 	got := CaptureScreen(screen)
-	assert.Equal(t, "\033[0;97;42mbar\033[0m", got)
+	assert.Equal(t, sgr(sgrReset+fgWhite+bgGreen)+"bar"+reset, got)
+}
+
+func TestCaptureScreen_StandardColor(t *testing.T) {
+	screen := initScreen(t, 5, 1)
+	// ColorBlack (index 0) is a standard color, should use base range (30-37).
+	style := tcell.StyleDefault.Foreground(tcell.ColorBlack)
+	putString(screen, 0, 0, "dark", style)
+	screen.Show()
+
+	got := CaptureScreen(screen)
+	assert.Equal(t, sgr(sgrReset+sgrFg(0))+"dark"+reset, got)
+}
+
+func TestCaptureScreen_HighIntensityColor(t *testing.T) {
+	screen := initScreen(t, 5, 1)
+	// ColorRed (index 9) is a high-intensity color, should use bright range (90-97).
+	style := tcell.StyleDefault.Foreground(tcell.ColorRed)
+	putString(screen, 0, 0, "glow", style)
+	screen.Show()
+
+	got := CaptureScreen(screen)
+	assert.Equal(t, sgr(sgrReset+sgrFg(9))+"glow"+reset, got)
+}
+
+func TestCaptureScreen_StandardAndHighIntensityBackground(t *testing.T) {
+	screen := initScreen(t, 6, 1)
+	// ColorGreen (index 2) is standard, ColorBlue (index 12) is high-intensity.
+	putString(screen, 0, 0, "std", tcell.StyleDefault.Background(tcell.ColorGreen))
+	putString(screen, 3, 0, "brt", tcell.StyleDefault.Background(tcell.ColorBlue))
+	screen.Show()
+
+	got := CaptureScreen(screen)
+	assert.Equal(t, sgr(sgrReset+sgrBg(2))+"std"+sgr(sgrReset+sgrBg(12))+"brt"+reset, got)
 }
 
 func TestCaptureScreen_EmptyScreen(t *testing.T) {

--- a/app/testutil/testutil.go
+++ b/app/testutil/testutil.go
@@ -8,9 +8,9 @@ import (
 )
 
 func InitSimScreen(t *testing.T, width int, height int) tcell.SimulationScreen {
+	t.Helper()
 	screen := tcell.NewSimulationScreen("")
-	err := screen.Init()
-	if err != nil {
+	if err := screen.Init(); err != nil {
 		t.Fatal(err)
 	}
 	screen.SetSize(width, height)


### PR DESCRIPTION
## Summary
- Capture the alternate screen buffer contents before `screen.Fini()` and print them to stdout with ANSI escape sequences, so the treemap remains visible in terminal scrollback after exit
- All exit paths (normal quit, context cancel, panic) flow through `cleanup()`, so a single capture point covers everything
- ANSI SGR constants are documented with named constants referencing ECMA-48

## Test plan
- [x] `go test -v ./...` — all tests pass
- [x] Run `dux .`, press `q`, verify the treemap remains visible in scrollback with correct colors
- [x] Run `dux .`, press `Ctrl-C`, verify same behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)